### PR TITLE
Add support for multiple usernames

### DIFF
--- a/includes/class-timeline-twitter-feed-shortcode.php
+++ b/includes/class-timeline-twitter-feed-shortcode.php
@@ -77,7 +77,10 @@ class Timeline_Twitter_Feed_Shortcode {
 			$num_tweets = (int) $this->basic_options[Timeline_Twitter_Feed_Options::NUM_TWEETS];
 
 			$tweets = array();
-			if ( 'on' !== $this->advanced_options[Timeline_Twitter_Feed_Options::ONLY_HASHTAGS] ) {
+			if(isset($atts['username'])) {
+                                $tweets = $twitter_app->get_tweets( esc_attr($atts['username']), $num_tweets );
+				$num_hashtag_tweets = $num_tweets;
+                        } else if ( 'on' !== $this->advanced_options[Timeline_Twitter_Feed_Options::ONLY_HASHTAGS] ) {
 				$tweets = $twitter_app->get_tweets( $this->basic_options[Timeline_Twitter_Feed_Options::USERNAME], $num_tweets );
 				$num_hashtag_tweets = $num_tweets;
 			} else {


### PR DESCRIPTION
Hi,

I changed the shortcode code a bit so that you can now have an "username" attr, which allows you to use a different username.

This is due to the fact that the search API for "from:username" gives so few results that using terms is not an option for many sites.

A-P